### PR TITLE
updates to handle upcoming package name change

### DIFF
--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -91,9 +91,16 @@ service 'cdap-master' do
   action node['cdap']['master']['init_actions']
 end
 
+upgrade_class =
+  if node['cdap']['version'].to_f >= 6.0
+    'io.cdap.cdap.data.tools.UpgradeTool'
+  else
+    'co.cask.cdap.data.tools.UpgradeTool'
+  end
+
 # CDAP Upgrade Tool
 execute 'cdap-upgrade-tool' do
-  command "#{node['cdap']['master']['init_cmd']} run co.cask.cdap.data.tools.UpgradeTool upgrade force"
+  command "#{node['cdap']['master']['init_cmd']} run #{upgrade_class} upgrade force"
   action :nothing
   user node['cdap']['master']['user']
 end

--- a/recipes/security.rb
+++ b/recipes/security.rb
@@ -38,7 +38,8 @@ end
 # Manage Authentication realmfile
 if node['cdap']['security']['manage_realmfile'].to_s == 'true' &&
    cdap_property?('security.authentication.handlerClassName') &&
-   node['cdap']['cdap_site']['security.authentication.handlerClassName'] == 'co.cask.cdap.security.server.BasicAuthenticationHandler' &&
+   (node['cdap']['cdap_site']['security.authentication.handlerClassName'] == 'co.cask.cdap.security.server.BasicAuthenticationHandler' ||
+   node['cdap']['cdap_site']['security.authentication.handlerClassName'] == 'io.cdap.cdap.security.server.BasicAuthenticationHandler') &&
    cdap_property?('security.authentication.basic.realmfile')
   include_recipe 'cdap::security_realm_file'
 end

--- a/spec/unit/security_spec.rb
+++ b/spec/unit/security_spec.rb
@@ -33,7 +33,7 @@ describe 'cdap::security' do
       ChefSpec::SoloRunner.new(platform: 'centos', version: 6.9) do |node|
         node.automatic['domain'] = 'example.com'
         node.override['cdap']['security']['manage_realmfile'] = true
-        node.override['cdap']['cdap_site']['security.authentication.handlerClassName'] = 'co.cask.cdap.security.server.BasicAuthenticationHandler'
+        node.override['cdap']['cdap_site']['security.authentication.handlerClassName'] = 'io.cdap.cdap.security.server.BasicAuthenticationHandler'
         node.override['cdap']['cdap_site']['security.authentication.basic.realmfile'] = '/test/tmp/testrealm'
         node.override['cdap']['security']['realmfile']['testuser'] = 'testpass'
         stub_command(/update-alternatives --display /).and_return(false)


### PR DESCRIPTION
changes to support package rename changes in https://github.com/cdapio/cdap/pull/11261

   - [x] sets the upgradeTool command correctly depending on version attribute
   - [x] configures the realmfile if either old or new classname specified